### PR TITLE
Support pulp v3 and a bit of spec rework

### DIFF
--- a/galaxycollection_to_rpm/data/template.j2
+++ b/galaxycollection_to_rpm/data/template.j2
@@ -6,6 +6,7 @@ License:        {{ info.metadata.license[0] | default('UNKNOWN') }}
 URL:            {{ info.metadata.homepage }}
 Source0:        {{ info.download_url }}
 BuildArch:      noarch
+BuildRequires:  ansible-packaging
 
 Requires:       ansible
 {% for dep in info.metadata.dependencies -%}
@@ -13,22 +14,22 @@ Requires:       ansible-collection-{{ dep }} >= {{ info.metadata.dependencies[de
 {% endfor %}
 
 %description
-{{ info.metadata.description }}
+%{summary}
 
 %prep
-%autosetup -c ansible-collection-{{ info.namespace.name }}-{{ info.collection.name }}-%{version}-%{release}
+%autosetup -c %{name}-%{version}-%{release}
+find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{}' +
 
 %build
+%ansible_collection_build
 
 
 %install
-install -d -m 0755 %{buildroot}/%{_datadir}/ansible/collections/ansible_collections/{{ info.namespace.name }}/{{ info.collection.name }}/
-cp -rp * %{buildroot}/%{_datadir}/ansible/collections/ansible_collections/{{ info.namespace.name }}/{{ info.collection.name }}/
+%ansible_collection_install
 
-%files
+%files -f %{ansible_collection_filelist}
 {% if info.metadata.license_file %}%license {{ info.metadata.license_file }} {%- endif %}
 {% if info.metadata.readme %}%doc {{ info.metadata.readme }} {%- endif %}
-%{_datadir}/ansible/collections/ansible_collections/{{ info.namespace.name }}/{{ info.collection.name }}/
 
 
 %changelog

--- a/galaxycollection_to_rpm/data/template.j2
+++ b/galaxycollection_to_rpm/data/template.j2
@@ -1,7 +1,7 @@
 Name:           ansible-collection-{{ info.namespace.name }}-{{ info.collection.name }}
 Version:        {{ info.version }}
 Release:        1
-Summary:        {{ info.metadata.description }}
+Summary:        {{ info.metadata.description | default('None') }}
 License:        {{ info.metadata.license[0] | default('UNKNOWN') }}
 URL:            {{ info.metadata.homepage }}
 Source0:        {{ info.download_url }}

--- a/galaxycollection_to_rpm/galaxycollection_to_rpm.py
+++ b/galaxycollection_to_rpm/galaxycollection_to_rpm.py
@@ -32,15 +32,15 @@ def create_spec(collection, output_file):
         print('Could not find template.j2 file. Please check your setup')
         sys.exit(1)
 
-    r = requests.get('https://galaxy.ansible.com/api/v2/collections/%s/' %
+    r = requests.get('https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/%s/' %
                      collection.replace('-', '/').replace('.', '/'))
     if r.status_code != 200:
         print('Error %s accessing %s' % (r.status_code, r.url))
         sys.exit(1)
 
-    latest_version = r.json()['latest_version']['version']
-    latest_v_url = r.json()['latest_version']['href']
-    r = requests.get(latest_v_url)
+    latest_version = r.json()['highest_version']['version']
+    latest_v_url = r.json()['highest_version']['href']
+    r = requests.get("https://galaxy.ansible.com%s" % latest_v_url)
     if r.status_code != 200:
         print('Error %s accessing %s' % (r.status_code, r.url))
         sys.exit(1)


### PR DESCRIPTION
Ansible galaxy migrated to pulp v3 some time in the last year, URLs changed a little bit.
Reworked the spec file a little bit to use the provided RPM macros from ansible-packaging.